### PR TITLE
Add registry routes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: MIX_ENV=prod mix phoenix.server

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,8 +10,16 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 config :ellion, EllionWeb.Endpoint,
-  url: [host: "example.com", port: 80],
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  url: [scheme: "https", host: "ellion.herokuapp.com", port: 443],
+  force_ssl: [rewrite_on: [:x_forwarded_proto]],
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  secret_key_base: System.get_env("SECRET_KEY_BASE")
+
+config :ellion, Ellion.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  url: System.get_env("DATABASE_URL"),
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  ssl: true
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/lib/ellion/geo.ex
+++ b/lib/ellion/geo.ex
@@ -3,9 +3,8 @@ defmodule Ellion.Geo do
   Geolocation context.
   """
 
-  import Ecto.Query, warn: false
-
   alias Ellion.Geo.Country
+  alias Ellion.Geo.State
   alias Ellion.Repo
 
   @doc """
@@ -37,10 +36,10 @@ defmodule Ellion.Geo do
     {:ok, country}
   rescue
     Ecto.NoResultsError ->
-      {:error, Country.error_changeset(:id, id, "not found")}
+      {:error, Country.error_changeset(:id, id, "not found [country]")}
 
     Ecto.Query.CastError ->
-      {:error, Country.error_changeset(:id, id, "invalid uuid")}
+      {:error, Country.error_changeset(:id, id, "invalid format [country]")}
   end
 
   @doc """
@@ -106,5 +105,105 @@ defmodule Ellion.Geo do
   """
   def change_country(%Country{} = country, attrs \\ %{}) do
     Country.changeset(country, attrs)
+  end
+
+  @doc """
+  Returns the list of states.
+
+  ## Examples
+
+      iex> list_states()
+      [%State{}, ...]
+
+  """
+  def list_states, do: Repo.all(State)
+
+  @doc """
+  Gets a single state.
+
+  ## Examples
+
+      iex> get_state(valid_uuid)
+      {:ok, %State{}}
+
+      iex> get_state(invalid_uuid)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def get_state(id) do
+    state = Repo.get!(State, id)
+
+    {:ok, state}
+  rescue
+    Ecto.NoResultsError ->
+      {:error, State.error_changeset(:id, id, "not found [state]")}
+
+    Ecto.Query.CastError ->
+      {:error, State.error_changeset(:id, id, "invalid format [state]")}
+  end
+
+  @doc """
+  Creates a state.
+
+  ## Examples
+
+      iex> create_state(%{field: value})
+      {:ok, %State{}}
+
+      iex> create_state(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_state(attrs \\ %{}) do
+    %State{}
+    |> State.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a state.
+
+  ## Examples
+
+      iex> update_state(state, %{field: new_value})
+      {:ok, %State{}}
+
+      iex> update_state(state, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_state(%State{} = state, attrs) do
+    state
+    |> State.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a state.
+
+  ## Examples
+
+      iex> delete_state(state)
+      {:ok, %State{}}
+
+      iex> delete_state(state)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_state(%State{} = state) do
+    Repo.delete(state)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking state changes.
+
+  ## Examples
+
+      iex> change_state(state)
+      %Ecto.Changeset{data: %State{}}
+
+  """
+  def change_state(%State{} = state, attrs \\ %{}) do
+    State.changeset(state, attrs)
   end
 end

--- a/lib/ellion/geo.ex
+++ b/lib/ellion/geo.ex
@@ -2,7 +2,7 @@ defmodule Ellion.Geo do
   @moduledoc """
   Geolocation context.
   """
-
+  alias Ellion.Geo.City
   alias Ellion.Geo.Country
   alias Ellion.Geo.State
   alias Ellion.Repo
@@ -205,5 +205,105 @@ defmodule Ellion.Geo do
   """
   def change_state(%State{} = state, attrs \\ %{}) do
     State.changeset(state, attrs)
+  end
+
+  @doc """
+  Returns the list of cities.
+
+  ## Examples
+
+      iex> list_cities()
+      [%City{}, ...]
+
+  """
+  def list_cities, do: Repo.all(City)
+
+  @doc """
+  Gets a single city.
+
+  ## Examples
+
+      iex> get_city(valid_uuid)
+      {:ok, %City{}}
+
+      iex> get_city(invalid_uuid)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def get_city(id) do
+    city = Repo.get!(City, id)
+
+    {:ok, city}
+  rescue
+    Ecto.NoResultsError ->
+      {:error, City.error_changeset(:id, id, "not found [city]")}
+
+    Ecto.Query.CastError ->
+      {:error, City.error_changeset(:id, id, "invalid format [city]")}
+  end
+
+  @doc """
+  Creates a city.
+
+  ## Examples
+
+      iex> create_city(%{field: value})
+      {:ok, %City{}}
+
+      iex> create_city(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_city(attrs \\ %{}) do
+    %City{}
+    |> City.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a city.
+
+  ## Examples
+
+      iex> update_city(city, %{field: new_value})
+      {:ok, %City{}}
+
+      iex> update_city(city, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_city(%City{} = city, attrs) do
+    city
+    |> City.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a city.
+
+  ## Examples
+
+      iex> delete_city(city)
+      {:ok, %City{}}
+
+      iex> delete_city(city)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_city(%City{} = city) do
+    Repo.delete(city)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking city changes.
+
+  ## Examples
+
+      iex> change_city(city)
+      %Ecto.Changeset{data: %City{}}
+
+  """
+  def change_city(%City{} = city, attrs \\ %{}) do
+    City.changeset(city, attrs)
   end
 end

--- a/lib/ellion/geo.ex
+++ b/lib/ellion/geo.ex
@@ -1,0 +1,110 @@
+defmodule Ellion.Geo do
+  @moduledoc """
+  Geolocation context.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Ellion.Geo.Country
+  alias Ellion.Repo
+
+  @doc """
+  Returns the list of countries.
+
+  ## Examples
+
+      iex> list_countries()
+      [%Country{}, ...]
+
+  """
+  def list_countries, do: Repo.all(Country)
+
+  @doc """
+  Gets a single country.
+
+  ## Examples
+
+      iex> get_country(valid_uuid)
+      {:ok, %Country{}}
+
+      iex> get_country(invalid_uuid)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def get_country(id) do
+    country = Repo.get!(Country, id)
+
+    {:ok, country}
+  rescue
+    Ecto.NoResultsError ->
+      {:error, Country.error_changeset(:id, id, "not found")}
+
+    Ecto.Query.CastError ->
+      {:error, Country.error_changeset(:id, id, "invalid uuid")}
+  end
+
+  @doc """
+  Creates a country.
+
+  ## Examples
+
+      iex> create_country(%{field: value})
+      {:ok, %Country{}}
+
+      iex> create_country(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_country(attrs \\ %{}) do
+    %Country{}
+    |> Country.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a country.
+
+  ## Examples
+
+      iex> update_country(country, %{field: new_value})
+      {:ok, %Country{}}
+
+      iex> update_country(country, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_country(%Country{} = country, attrs) do
+    country
+    |> Country.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a country.
+
+  ## Examples
+
+      iex> delete_country(country)
+      {:ok, %Country{}}
+
+      iex> delete_country(country)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_country(%Country{} = country) do
+    Repo.delete(country)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking country changes.
+
+  ## Examples
+
+      iex> change_country(country)
+      %Ecto.Changeset{data: %Country{}}
+
+  """
+  def change_country(%Country{} = country, attrs \\ %{}) do
+    Country.changeset(country, attrs)
+  end
+end

--- a/lib/ellion/geo/city.ex
+++ b/lib/ellion/geo/city.ex
@@ -1,0 +1,26 @@
+defmodule Ellion.Geo.City do
+  use Ellion.Schema
+
+  import Ecto.Changeset
+
+  alias Ellion.Geo.State
+  alias Ellion.Utils.Validator
+
+  schema "cities" do
+    field :name, :string
+    belongs_to :state, State
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(city, attrs) do
+    city
+    |> cast(attrs, [:id, :name, :state_id])
+    |> validate_required([:name])
+    |> validate_length(:name, min: 2, max: 150)
+    |> update_change(:id, &Validator.cast_uuid/1)
+    |> unique_constraint(:id, name: :cities_pkey)
+    |> assoc_constraint(:state)
+  end
+end

--- a/lib/ellion/geo/city.ex
+++ b/lib/ellion/geo/city.ex
@@ -4,11 +4,13 @@ defmodule Ellion.Geo.City do
   import Ecto.Changeset
 
   alias Ellion.Geo.State
+  alias Ellion.Registry.Address
   alias Ellion.Utils.Validator
 
   schema "cities" do
     field :name, :string
     belongs_to :state, State
+    has_many :addresses, Address
 
     timestamps()
   end

--- a/lib/ellion/geo/country.ex
+++ b/lib/ellion/geo/country.ex
@@ -1,0 +1,28 @@
+defmodule Ellion.Geo.Country do
+  use Ellion.Schema
+
+  import Ecto.Changeset
+
+  alias Ellion.Utils.Validator
+
+  schema "countries" do
+    field :code, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(country, attrs) do
+    country
+    |> cast(attrs, [:id, :name, :code])
+    |> validate_required([:name, :code])
+    |> unique_constraint(:code)
+    |> validate_length(:code, is: 3)
+    |> update_change(:code, &String.upcase/1)
+    |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")
+    |> validate_length(:name, min: 2, max: 150)
+    |> update_change(:id, &Validator.cast_uuid/1)
+    |> unique_constraint(:id, name: :countries_pkey)
+  end
+end

--- a/lib/ellion/geo/state.ex
+++ b/lib/ellion/geo/state.ex
@@ -3,6 +3,7 @@ defmodule Ellion.Geo.State do
 
   import Ecto.Changeset
 
+  alias Ellion.Geo.City
   alias Ellion.Geo.Country
   alias Ellion.Utils.Validator
 
@@ -10,6 +11,7 @@ defmodule Ellion.Geo.State do
     field :code, :string
     field :name, :string
     belongs_to :country, Country
+    has_many :cities, City
 
     timestamps()
   end
@@ -18,6 +20,7 @@ defmodule Ellion.Geo.State do
   def changeset(state, attrs) do
     state
     |> cast(attrs, [:id, :code, :name, :country_id])
+    |> cast_assoc(:cities)
     |> validate_required([:code, :name])
     |> unique_constraint(:code)
     |> validate_length(:code, is: 2)

--- a/lib/ellion/geo/state.ex
+++ b/lib/ellion/geo/state.ex
@@ -1,24 +1,23 @@
-defmodule Ellion.Geo.Country do
+defmodule Ellion.Geo.State do
   use Ellion.Schema
 
   import Ecto.Changeset
 
-  alias Ellion.Geo.State
+  alias Ellion.Geo.Country
   alias Ellion.Utils.Validator
 
-  schema "countries" do
+  schema "states" do
     field :code, :string
     field :name, :string
-    has_many :states, State
+    belongs_to :country, Country
 
     timestamps()
   end
 
   @doc false
-  def changeset(country, attrs) do
-    country
-    |> cast(attrs, [:id, :code, :name])
-    |> cast_assoc(:states)
+  def changeset(state, attrs) do
+    state
+    |> cast(attrs, [:id, :code, :name, :country_id])
     |> validate_required([:code, :name])
     |> unique_constraint(:code)
     |> validate_length(:code, is: 2)
@@ -26,6 +25,7 @@ defmodule Ellion.Geo.Country do
     |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")
     |> validate_length(:name, min: 2, max: 150)
     |> update_change(:id, &Validator.cast_uuid/1)
-    |> unique_constraint(:id, name: :countries_pkey)
+    |> unique_constraint(:id, name: :states_pkey)
+    |> assoc_constraint(:country)
   end
 end

--- a/lib/ellion/helper/validator.ex
+++ b/lib/ellion/helper/validator.ex
@@ -1,0 +1,22 @@
+defmodule Ellion.Utils.Validator do
+  @moduledoc """
+  Validation utilities.
+  """
+
+  @doc """
+  Casts uuid.
+
+  Returns nil when invalid.
+  """
+  def cast_uuid(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, _uuid} -> id
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Validates a uuid.
+  """
+  def valid?(id), do: cast_uuid(id) != nil
+end

--- a/lib/ellion/registry.ex
+++ b/lib/ellion/registry.ex
@@ -1,0 +1,108 @@
+defmodule Ellion.Registry do
+  @moduledoc """
+  Registry context.
+  """
+
+  alias Ellion.Registry.Person
+  alias Ellion.Repo
+
+  @doc """
+  Returns the list of persons.
+
+  ## Examples
+
+      iex> list_persons()
+      [%Person{}, ...]
+
+  """
+  def list_persons, do: Repo.all(Person)
+
+  @doc """
+  Gets a single person.
+
+  ## Examples
+
+      iex> get_person!(valid_uuid)
+      {:ok, %Person{}}
+
+      iex> get_person!(invalid_uuid)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def get_person(id) do
+    person = Repo.get!(Person, id)
+
+    {:ok, person}
+  rescue
+    Ecto.NoResultsError ->
+      {:error, Person.error_changeset(:id, id, "not found [person]")}
+
+    Ecto.Query.CastError ->
+      {:error, Person.error_changeset(:id, id, "invalid format [person]")}
+  end
+
+  @doc """
+  Creates a person.
+
+  ## Examples
+
+      iex> create_person(%{field: value})
+      {:ok, %Person{}}
+
+      iex> create_person(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_person(attrs \\ %{}) do
+    %Person{}
+    |> Person.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a person.
+
+  ## Examples
+
+      iex> update_person(person, %{field: new_value})
+      {:ok, %Person{}}
+
+      iex> update_person(person, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_person(%Person{} = person, attrs) do
+    person
+    |> Person.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a person.
+
+  ## Examples
+
+      iex> delete_person(person)
+      {:ok, %Person{}}
+
+      iex> delete_person(person)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_person(%Person{} = person) do
+    Repo.delete(person)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking person changes.
+
+  ## Examples
+
+      iex> change_person(person)
+      %Ecto.Changeset{data: %Person{}}
+
+  """
+  def change_person(%Person{} = person, attrs \\ %{}) do
+    Person.changeset(person, attrs)
+  end
+end

--- a/lib/ellion/registry.ex
+++ b/lib/ellion/registry.ex
@@ -3,6 +3,7 @@ defmodule Ellion.Registry do
   Registry context.
   """
 
+  alias Ellion.Registry.Address
   alias Ellion.Registry.Person
   alias Ellion.Repo
 
@@ -104,5 +105,105 @@ defmodule Ellion.Registry do
   """
   def change_person(%Person{} = person, attrs \\ %{}) do
     Person.changeset(person, attrs)
+  end
+
+  @doc """
+  Returns the list of addresses.
+
+  ## Examples
+
+      iex> list_addresses()
+      [%Address{}, ...]
+
+  """
+  def list_addresses, do: Repo.all(Address)
+
+  @doc """
+  Gets a single address.
+
+  ## Examples
+
+      iex> get_address(valid_uuid)
+      {:ok, %Address{}}
+
+      iex> get_address(invalid_uuid)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def get_address(id) do
+    address = Repo.get!(Address, id)
+
+    {:ok, address}
+  rescue
+    Ecto.NoResultsError ->
+      {:error, Address.error_changeset(:id, id, "not found [address]")}
+
+    Ecto.Query.CastError ->
+      {:error, Address.error_changeset(:id, id, "invalid format [address]")}
+  end
+
+  @doc """
+  Creates a address.
+
+  ## Examples
+
+      iex> create_address(%{field: value})
+      {:ok, %Address{}}
+
+      iex> create_address(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_address(attrs \\ %{}) do
+    %Address{}
+    |> Address.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a address.
+
+  ## Examples
+
+      iex> update_address(address, %{field: new_value})
+      {:ok, %Address{}}
+
+      iex> update_address(address, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_address(%Address{} = address, attrs) do
+    address
+    |> Address.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a address.
+
+  ## Examples
+
+      iex> delete_address(address)
+      {:ok, %Address{}}
+
+      iex> delete_address(address)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_address(%Address{} = address) do
+    Repo.delete(address)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking address changes.
+
+  ## Examples
+
+      iex> change_address(address)
+      %Ecto.Changeset{data: %Address{}}
+
+  """
+  def change_address(%Address{} = address, attrs \\ %{}) do
+    Address.changeset(address, attrs)
   end
 end

--- a/lib/ellion/registry/address.ex
+++ b/lib/ellion/registry/address.ex
@@ -1,0 +1,42 @@
+defmodule Ellion.Registry.Address do
+  use Ellion.Schema
+
+  import Ecto.Changeset
+
+  alias Ellion.Geo.City
+  alias Ellion.Registry.Person
+  alias Ellion.Utils.Validator
+
+  @required [:alias, :street, :zip, :city_id]
+
+  schema "addresses" do
+    field :alias, :string
+    field :street, :string
+    field :number, :string
+    field :complement, :string
+    field :neighborhood, :string
+    field :zip, :string
+    belongs_to :city, City
+    belongs_to :person, Person
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(address, attrs) do
+    address
+    |> cast(attrs, @required ++ [:id, :number, :complement, :neighborhood, :person_id])
+    |> validate_required(@required)
+    |> validate_length(:alias, max: 15)
+    |> validate_length(:street, min: 2, max: 150)
+    |> validate_length(:number, max: 15)
+    |> validate_length(:complement, max: 100)
+    |> validate_length(:neighborhood, max: 100)
+    |> validate_length(:zip, min: 2, max: 15)
+    |> validate_format(:zip, ~r/^[0-9]+$/, message: "must contain only numbers")
+    |> update_change(:id, &Validator.cast_uuid/1)
+    |> unique_constraint(:id, name: :addresses_pkey)
+    |> assoc_constraint(:city)
+    |> assoc_constraint(:person)
+  end
+end

--- a/lib/ellion/registry/person.ex
+++ b/lib/ellion/registry/person.ex
@@ -1,0 +1,29 @@
+defmodule Ellion.Registry.Person do
+  use Ellion.Schema
+
+  import Ecto.Changeset
+
+  alias Ellion.Utils.Validator
+
+  schema "persons" do
+    field :alias, :string
+    field :name, :string
+    field :social_id, :string
+    field :type, Ecto.Enum, values: [natural: 0, juridical: 1, other: 2]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(person, attrs) do
+    person
+    |> cast(attrs, [:id, :alias, :name, :social_id, :type])
+    |> validate_required([:name, :social_id, :type])
+    |> validate_length(:alias, max: 50)
+    |> validate_length(:name, min: 2, max: 150)
+    |> validate_length(:social_id, min: 2, max: 15)
+    |> validate_format(:social_id, ~r/^[0-9]+$/, message: "must contain only numbers")
+    |> update_change(:id, &Validator.cast_uuid/1)
+    |> unique_constraint(:id, name: :persons_pkey)
+  end
+end

--- a/lib/ellion/registry/person.ex
+++ b/lib/ellion/registry/person.ex
@@ -3,6 +3,7 @@ defmodule Ellion.Registry.Person do
 
   import Ecto.Changeset
 
+  alias Ellion.Registry.Address
   alias Ellion.Utils.Validator
 
   schema "persons" do
@@ -10,6 +11,7 @@ defmodule Ellion.Registry.Person do
     field :name, :string
     field :social_id, :string
     field :type, Ecto.Enum, values: [natural: 0, juridical: 1, other: 2]
+    has_many :addresses, Address
 
     timestamps()
   end
@@ -18,6 +20,7 @@ defmodule Ellion.Registry.Person do
   def changeset(person, attrs) do
     person
     |> cast(attrs, [:id, :alias, :name, :social_id, :type])
+    |> cast_assoc(:addresses)
     |> validate_required([:name, :social_id, :type])
     |> validate_length(:alias, max: 50)
     |> validate_length(:name, min: 2, max: 150)

--- a/lib/ellion/schema.ex
+++ b/lib/ellion/schema.ex
@@ -6,9 +6,31 @@ defmodule Ellion.Schema do
   defmacro __using__(_) do
     quote do
       use Ecto.Schema
+
       @primary_key {:id, :binary_id, autogenerate: true}
       @foreign_key_type :binary_id
       @timestamps_opts [type: :utc_datetime]
+
+      @doc """
+      Creates a changeset with errors.
+
+      ## Examples
+
+          iex> error_changeset(:id, 123, "invalid uuid", [validation: :format])
+          %Ecto.Changeset{
+              action: nil,
+              changes: %{id: 123},
+              errors: [id: {"invalid uuid", [validation: :format]}],
+              data: #Module.Schema<>,
+              valid?: false
+          }
+
+      """
+      def error_changeset(field, value, message, additional_info \\ []) do
+        struct(__MODULE__)
+        |> Ecto.Changeset.change(%{field => value})
+        |> Ecto.Changeset.add_error(field, message, additional_info)
+      end
     end
   end
 end

--- a/lib/ellion/schema.ex
+++ b/lib/ellion/schema.ex
@@ -11,6 +11,9 @@ defmodule Ellion.Schema do
       @foreign_key_type :binary_id
       @timestamps_opts [type: :utc_datetime]
 
+      @doc false
+      def changeset(attrs), do: changeset(struct(__MODULE__), attrs)
+
       @doc """
       Creates a changeset with errors.
 

--- a/lib/ellion_web/controllers/address_controller.ex
+++ b/lib/ellion_web/controllers/address_controller.ex
@@ -1,0 +1,57 @@
+defmodule EllionWeb.AddressController do
+  use EllionWeb, :controller
+
+  alias Ellion.Registry
+  alias Ellion.Registry.Address
+  alias Ellion.Registry.Person
+
+  action_fallback EllionWeb.FallbackController
+
+  def index(conn, %{"person_id" => person_id}) do
+    with {:ok, %Person{}} <- Registry.get_person(person_id) do
+      render(conn, "index.json", addresses: Registry.list_addresses())
+    end
+  end
+
+  def create(conn, %{"person_id" => person_id, "address" => address_params}) do
+    with {:ok, %Person{}} <- Registry.get_person(person_id) do
+      address_params = Map.put(address_params, "person_id", person_id)
+
+      with {:ok, %Address{} = address} <- Registry.create_address(address_params) do
+        conn
+        |> put_status(:created)
+        |> put_resp_header(
+          "location",
+          Routes.person_address_path(conn, :show, person_id, address)
+        )
+        |> render("show.json", address: address)
+      end
+    end
+  end
+
+  def show(conn, %{"person_id" => person_id, "id" => id}) do
+    with {:ok, %Address{} = address} <- get_address(person_id, id) do
+      render(conn, "show.json", address: address)
+    end
+  end
+
+  def update(conn, %{"person_id" => person_id, "id" => id, "address" => address_params}) do
+    with {:ok, %Address{} = address} <- get_address(person_id, id),
+         {:ok, %Address{} = address} <- Registry.update_address(address, address_params) do
+      render(conn, "show.json", address: address)
+    end
+  end
+
+  def delete(conn, %{"person_id" => person_id, "id" => id}) do
+    with {:ok, %Address{} = address} <- get_address(person_id, id),
+         {:ok, %Address{}} <- Registry.delete_address(address) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp get_address(person_id, id) do
+    with {:ok, %Person{}} <- Registry.get_person(person_id) do
+      Registry.get_address(id)
+    end
+  end
+end

--- a/lib/ellion_web/controllers/city_controller.ex
+++ b/lib/ellion_web/controllers/city_controller.ex
@@ -8,9 +8,11 @@ defmodule EllionWeb.CityController do
 
   action_fallback EllionWeb.FallbackController
 
-  def index(conn, _params) do
-    cities = Geo.list_cities()
-    render(conn, "index.json", cities: cities)
+  def index(conn, %{"country_id" => country_id, "state_id" => state_id}) do
+    with {:ok, %Country{}} <- Geo.get_country(country_id),
+         {:ok, %State{}} <- Geo.get_state(state_id) do
+      render(conn, "index.json", cities: Geo.list_cities())
+    end
   end
 
   def create(conn, %{"country_id" => country_id, "state_id" => state_id, "city" => city_params}) do

--- a/lib/ellion_web/controllers/city_controller.ex
+++ b/lib/ellion_web/controllers/city_controller.ex
@@ -1,0 +1,63 @@
+defmodule EllionWeb.CityController do
+  use EllionWeb, :controller
+
+  alias Ellion.Geo
+  alias Ellion.Geo.City
+  alias Ellion.Geo.Country
+  alias Ellion.Geo.State
+
+  action_fallback EllionWeb.FallbackController
+
+  def index(conn, _params) do
+    cities = Geo.list_cities()
+    render(conn, "index.json", cities: cities)
+  end
+
+  def create(conn, %{"country_id" => country_id, "state_id" => state_id, "city" => city_params}) do
+    with {:ok, %State{}} <- Geo.get_state(state_id) do
+      city_params = Map.put(city_params, "state_id", state_id)
+
+      with {:ok, %City{} = city} <- Geo.create_city(city_params) do
+        conn
+        |> put_status(:created)
+        |> put_resp_header(
+          "location",
+          Routes.country_state_city_path(conn, :show, country_id, state_id, city)
+        )
+        |> render("show.json", city: city)
+      end
+    end
+  end
+
+  def show(conn, %{"country_id" => country_id, "state_id" => state_id, "id" => id}) do
+    with {:ok, %City{} = city} <- get_city(country_id, state_id, id) do
+      render(conn, "show.json", city: city)
+    end
+  end
+
+  def update(conn, %{
+        "country_id" => country_id,
+        "state_id" => state_id,
+        "id" => id,
+        "city" => city_params
+      }) do
+    with {:ok, %City{} = city} <- get_city(country_id, state_id, id),
+         {:ok, %City{} = city} <- Geo.update_city(city, city_params) do
+      render(conn, "show.json", city: city)
+    end
+  end
+
+  def delete(conn, %{"country_id" => country_id, "state_id" => state_id, "id" => id}) do
+    with {:ok, %City{} = city} <- get_city(country_id, state_id, id),
+         {:ok, %City{}} <- Geo.delete_city(city) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp get_city(country_id, state_id, id) do
+    with {:ok, %Country{}} <- Geo.get_country(country_id),
+         {:ok, %State{}} <- Geo.get_state(state_id) do
+      Geo.get_city(id)
+    end
+  end
+end

--- a/lib/ellion_web/controllers/country_controller.ex
+++ b/lib/ellion_web/controllers/country_controller.ex
@@ -1,0 +1,40 @@
+defmodule EllionWeb.CountryController do
+  use EllionWeb, :controller
+
+  alias Ellion.Geo
+  alias Ellion.Geo.Country
+
+  def index(conn, _params) do
+    countries = Geo.list_countries()
+    render(conn, "index.json", countries: countries)
+  end
+
+  def create(conn, %{"country" => country_params}) do
+    with {:ok, %Country{} = country} <- Geo.create_country(country_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.country_path(conn, :show, country))
+      |> render("show.json", country: country)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    with {:ok, %Country{} = country} <- Geo.get_country(id) do
+      render(conn, "show.json", country: country)
+    end
+  end
+
+  def update(conn, %{"id" => id, "country" => country_params}) do
+    with {:ok, %Country{} = country} <- Geo.get_country(id),
+         {:ok, %Country{} = country} <- Geo.update_country(country, country_params) do
+      render(conn, "show.json", country: country)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    with {:ok, %Country{} = country} <- Geo.get_country(id),
+         {:ok, %Country{}} <- Geo.delete_country(country) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/ellion_web/controllers/country_controller.ex
+++ b/lib/ellion_web/controllers/country_controller.ex
@@ -7,8 +7,7 @@ defmodule EllionWeb.CountryController do
   action_fallback EllionWeb.FallbackController
 
   def index(conn, _params) do
-    countries = Geo.list_countries()
-    render(conn, "index.json", countries: countries)
+    render(conn, "index.json", countries: Geo.list_countries())
   end
 
   def create(conn, %{"country" => country_params}) do

--- a/lib/ellion_web/controllers/country_controller.ex
+++ b/lib/ellion_web/controllers/country_controller.ex
@@ -4,6 +4,8 @@ defmodule EllionWeb.CountryController do
   alias Ellion.Geo
   alias Ellion.Geo.Country
 
+  action_fallback EllionWeb.FallbackController
+
   def index(conn, _params) do
     countries = Geo.list_countries()
     render(conn, "index.json", countries: countries)

--- a/lib/ellion_web/controllers/fallback_controller.ex
+++ b/lib/ellion_web/controllers/fallback_controller.ex
@@ -1,0 +1,16 @@
+defmodule EllionWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+  """
+  use EllionWeb, :controller
+
+  @doc """
+  Handles errors returned by Ecto's changeset.
+  """
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(EllionWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+end

--- a/lib/ellion_web/controllers/person_controller.ex
+++ b/lib/ellion_web/controllers/person_controller.ex
@@ -7,8 +7,7 @@ defmodule EllionWeb.PersonController do
   action_fallback EllionWeb.FallbackController
 
   def index(conn, _params) do
-    persons = Registry.list_persons()
-    render(conn, "index.json", persons: persons)
+    render(conn, "index.json", persons: Registry.list_persons())
   end
 
   def create(conn, %{"person" => person_params}) do

--- a/lib/ellion_web/controllers/person_controller.ex
+++ b/lib/ellion_web/controllers/person_controller.ex
@@ -1,0 +1,42 @@
+defmodule EllionWeb.PersonController do
+  use EllionWeb, :controller
+
+  alias Ellion.Registry
+  alias Ellion.Registry.Person
+
+  action_fallback EllionWeb.FallbackController
+
+  def index(conn, _params) do
+    persons = Registry.list_persons()
+    render(conn, "index.json", persons: persons)
+  end
+
+  def create(conn, %{"person" => person_params}) do
+    with {:ok, %Person{} = person} <- Registry.create_person(person_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.person_path(conn, :show, person))
+      |> render("show.json", person: person)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    with {:ok, %Person{} = person} <- Registry.get_person(id) do
+      render(conn, "show.json", person: person)
+    end
+  end
+
+  def update(conn, %{"id" => id, "person" => person_params}) do
+    with {:ok, %Person{} = person} <- Registry.get_person(id),
+         {:ok, %Person{} = person} <- Registry.update_person(person, person_params) do
+      render(conn, "show.json", person: person)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    with {:ok, %Person{} = person} <- Registry.get_person(id),
+         {:ok, %Person{}} <- Registry.delete_person(person) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/ellion_web/controllers/state_controller.ex
+++ b/lib/ellion_web/controllers/state_controller.ex
@@ -1,0 +1,53 @@
+defmodule EllionWeb.StateController do
+  use EllionWeb, :controller
+
+  alias Ellion.Geo
+  alias Ellion.Geo.Country
+  alias Ellion.Geo.State
+
+  action_fallback EllionWeb.FallbackController
+
+  def index(conn, _params) do
+    states = Geo.list_states()
+    render(conn, "index.json", states: states)
+  end
+
+  def create(conn, %{"country_id" => country_id, "state" => state_params}) do
+    with {:ok, %Country{}} <- Geo.get_country(country_id) do
+      state_params = Map.put(state_params, "country_id", country_id)
+
+      with {:ok, %State{} = state} <- Geo.create_state(state_params) do
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", Routes.country_state_path(conn, :show, country_id, state))
+        |> render("show.json", state: state)
+      end
+    end
+  end
+
+  def show(conn, %{"country_id" => country_id, "id" => id}) do
+    with {:ok, %State{} = state} <- get_state(country_id, id) do
+      render(conn, "show.json", state: state)
+    end
+  end
+
+  def update(conn, %{"country_id" => country_id, "id" => id, "state" => state_params}) do
+    with {:ok, %State{} = state} <- get_state(country_id, id),
+         {:ok, %State{} = state} <- Geo.update_state(state, state_params) do
+      render(conn, "show.json", state: state)
+    end
+  end
+
+  def delete(conn, %{"country_id" => country_id, "id" => id}) do
+    with {:ok, %State{} = state} <- get_state(country_id, id),
+         {:ok, %State{}} <- Geo.delete_state(state) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+
+  defp get_state(country_id, id) do
+    with {:ok, %Country{}} <- Geo.get_country(country_id) do
+      Geo.get_state(id)
+    end
+  end
+end

--- a/lib/ellion_web/controllers/state_controller.ex
+++ b/lib/ellion_web/controllers/state_controller.ex
@@ -7,9 +7,10 @@ defmodule EllionWeb.StateController do
 
   action_fallback EllionWeb.FallbackController
 
-  def index(conn, _params) do
-    states = Geo.list_states()
-    render(conn, "index.json", states: states)
+  def index(conn, %{"country_id" => country_id}) do
+    with {:ok, %Country{}} <- Geo.get_country(country_id) do
+      render(conn, "index.json", states: Geo.list_states())
+    end
   end
 
   def create(conn, %{"country_id" => country_id, "state" => state_params}) do

--- a/lib/ellion_web/router.ex
+++ b/lib/ellion_web/router.ex
@@ -9,7 +9,9 @@ defmodule EllionWeb.Router do
     pipe_through :api
 
     resources "/countries", CountryController, except: [:new, :edit] do
-      resources "/states", StateController, except: [:new, :edit]
+      resources "/states", StateController, except: [:new, :edit] do
+        resources "/cities", CityController, except: [:new, :edit]
+      end
     end
   end
 

--- a/lib/ellion_web/router.ex
+++ b/lib/ellion_web/router.ex
@@ -13,6 +13,8 @@ defmodule EllionWeb.Router do
         resources "/cities", CityController, except: [:new, :edit]
       end
     end
+
+    resources "/persons", PersonController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/ellion_web/router.ex
+++ b/lib/ellion_web/router.ex
@@ -7,6 +7,8 @@ defmodule EllionWeb.Router do
 
   scope "/api", EllionWeb do
     pipe_through :api
+
+    resources "/countries", CountryController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/ellion_web/router.ex
+++ b/lib/ellion_web/router.ex
@@ -14,7 +14,9 @@ defmodule EllionWeb.Router do
       end
     end
 
-    resources "/persons", PersonController, except: [:new, :edit]
+    resources "/persons", PersonController, except: [:new, :edit] do
+      resources "/addresses", AddressController, except: [:new, :edit]
+    end
   end
 
   # Enables LiveDashboard only for development

--- a/lib/ellion_web/router.ex
+++ b/lib/ellion_web/router.ex
@@ -8,7 +8,9 @@ defmodule EllionWeb.Router do
   scope "/api", EllionWeb do
     pipe_through :api
 
-    resources "/countries", CountryController, except: [:new, :edit]
+    resources "/countries", CountryController, except: [:new, :edit] do
+      resources "/states", StateController, except: [:new, :edit]
+    end
   end
 
   # Enables LiveDashboard only for development

--- a/lib/ellion_web/views/address_view.ex
+++ b/lib/ellion_web/views/address_view.ex
@@ -1,0 +1,36 @@
+defmodule EllionWeb.AddressView do
+  use EllionWeb, :view
+
+  alias EllionWeb.AddressView
+
+  @doc """
+  Renders a list of addresses.
+  """
+  def render("index.json", %{addresses: addresses}) do
+    %{data: render_many(addresses, AddressView, "address.json"), success: true}
+  end
+
+  @doc """
+  Renders a single address.
+  """
+  def render("show.json", %{address: address}) do
+    %{data: render_one(address, AddressView, "address.json"), success: true}
+  end
+
+  @doc """
+  Renders address data.
+  """
+  def render("address.json", %{address: address}) do
+    %{
+      id: address.id,
+      alias: address.alias,
+      street: address.street,
+      number: address.number,
+      complement: address.complement,
+      neighborhood: address.neighborhood,
+      zip: address.zip,
+      city_id: address.city_id,
+      person_id: address.person_id
+    }
+  end
+end

--- a/lib/ellion_web/views/changeset_view.ex
+++ b/lib/ellion_web/views/changeset_view.ex
@@ -1,0 +1,17 @@
+defmodule EllionWeb.ChangesetView do
+  use EllionWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  @doc """
+  Renders errors returned by Ecto's changeset.
+  """
+  def render("error.json", %{changeset: changeset}) do
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/ellion_web/views/changeset_view.ex
+++ b/lib/ellion_web/views/changeset_view.ex
@@ -12,6 +12,6 @@ defmodule EllionWeb.ChangesetView do
   Renders errors returned by Ecto's changeset.
   """
   def render("error.json", %{changeset: changeset}) do
-    %{errors: translate_errors(changeset)}
+    %{errors: translate_errors(changeset), success: false}
   end
 end

--- a/lib/ellion_web/views/city_view.ex
+++ b/lib/ellion_web/views/city_view.ex
@@ -1,0 +1,30 @@
+defmodule EllionWeb.CityView do
+  use EllionWeb, :view
+
+  alias EllionWeb.CityView
+
+  @doc """
+  Renders a list of cities.
+  """
+  def render("index.json", %{cities: cities}) do
+    %{data: render_many(cities, CityView, "city.json"), success: true}
+  end
+
+  @doc """
+  Renders a single city.
+  """
+  def render("show.json", %{city: city}) do
+    %{data: render_one(city, CityView, "city.json"), success: true}
+  end
+
+  @doc """
+  Renders city data.
+  """
+  def render("city.json", %{city: city}) do
+    %{
+      id: city.id,
+      name: city.name,
+      state_id: city.state_id
+    }
+  end
+end

--- a/lib/ellion_web/views/country_view.ex
+++ b/lib/ellion_web/views/country_view.ex
@@ -1,0 +1,30 @@
+defmodule EllionWeb.CountryView do
+  use EllionWeb, :view
+
+  alias EllionWeb.CountryView
+
+  @doc """
+  Renders a list of countries.
+  """
+  def render("index.json", %{countries: countries}) do
+    %{data: render_many(countries, CountryView, "country.json")}
+  end
+
+  @doc """
+  Renders a single country.
+  """
+  def render("show.json", %{country: country}) do
+    %{data: render_one(country, CountryView, "country.json")}
+  end
+
+  @doc """
+  Renders country data.
+  """
+  def render("country.json", %{country: country}) do
+    %{
+      id: country.id,
+      code: country.code,
+      name: country.name
+    }
+  end
+end

--- a/lib/ellion_web/views/country_view.ex
+++ b/lib/ellion_web/views/country_view.ex
@@ -7,14 +7,14 @@ defmodule EllionWeb.CountryView do
   Renders a list of countries.
   """
   def render("index.json", %{countries: countries}) do
-    %{data: render_many(countries, CountryView, "country.json")}
+    %{data: render_many(countries, CountryView, "country.json"), success: true}
   end
 
   @doc """
   Renders a single country.
   """
   def render("show.json", %{country: country}) do
-    %{data: render_one(country, CountryView, "country.json")}
+    %{data: render_one(country, CountryView, "country.json"), success: true}
   end
 
   @doc """

--- a/lib/ellion_web/views/error_view.ex
+++ b/lib/ellion_web/views/error_view.ex
@@ -11,6 +11,9 @@ defmodule EllionWeb.ErrorView do
   # the template name. For example, "404.json" becomes
   # "Not Found".
   def template_not_found(template, _assigns) do
-    %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
+    %{
+      errors: %{detail: Phoenix.Controller.status_message_from_template(template)},
+      success: false
+    }
   end
 end

--- a/lib/ellion_web/views/person_view.ex
+++ b/lib/ellion_web/views/person_view.ex
@@ -1,0 +1,32 @@
+defmodule EllionWeb.PersonView do
+  use EllionWeb, :view
+
+  alias EllionWeb.PersonView
+
+  @doc """
+  Renders a list of persons.
+  """
+  def render("index.json", %{persons: persons}) do
+    %{data: render_many(persons, PersonView, "person.json"), success: true}
+  end
+
+  @doc """
+  Renders a single person.
+  """
+  def render("show.json", %{person: person}) do
+    %{data: render_one(person, PersonView, "person.json"), success: true}
+  end
+
+  @doc """
+  Renders person data.
+  """
+  def render("person.json", %{person: person}) do
+    %{
+      id: person.id,
+      alias: person.alias,
+      name: person.name,
+      social_id: person.social_id,
+      type: person.type
+    }
+  end
+end

--- a/lib/ellion_web/views/state_view.ex
+++ b/lib/ellion_web/views/state_view.ex
@@ -1,0 +1,31 @@
+defmodule EllionWeb.StateView do
+  use EllionWeb, :view
+
+  alias EllionWeb.StateView
+
+  @doc """
+  Renders a list of states.
+  """
+  def render("index.json", %{states: states}) do
+    %{data: render_many(states, StateView, "state.json"), success: true}
+  end
+
+  @doc """
+  Renders a single state.
+  """
+  def render("show.json", %{state: state}) do
+    %{data: render_one(state, StateView, "state.json"), success: true}
+  end
+
+  @doc """
+  Renders state data.
+  """
+  def render("state.json", %{state: state}) do
+    %{
+      id: state.id,
+      code: state.code,
+      name: state.name,
+      country_id: state.country_id
+    }
+  end
+end

--- a/priv/repo/migrations/20220601231921_create_countries.exs
+++ b/priv/repo/migrations/20220601231921_create_countries.exs
@@ -1,0 +1,14 @@
+defmodule Ellion.Repo.Migrations.CreateCountries do
+  use Ecto.Migration
+
+  def change do
+    create table(:countries) do
+      add :code, :string, size: 5, null: false
+      add :name, :string, size: 150, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:countries, [:code])
+  end
+end

--- a/priv/repo/migrations/20220602014200_create_states.exs
+++ b/priv/repo/migrations/20220602014200_create_states.exs
@@ -1,0 +1,15 @@
+defmodule Ellion.Repo.Migrations.CreateStates do
+  use Ecto.Migration
+
+  def change do
+    create table(:states) do
+      add :code, :string, size: 5, null: false
+      add :name, :string, size: 150, null: false
+      add :country_id, references(:countries, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:states, [:country_id])
+  end
+end

--- a/priv/repo/migrations/20220603011447_create_cities.exs
+++ b/priv/repo/migrations/20220603011447_create_cities.exs
@@ -1,0 +1,14 @@
+defmodule Ellion.Repo.Migrations.CreateCities do
+  use Ecto.Migration
+
+  def change do
+    create table(:cities) do
+      add :name, :string, size: 150, null: false
+      add :state_id, references(:states, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:cities, [:state_id])
+  end
+end

--- a/priv/repo/migrations/20220604175030_create_persons.exs
+++ b/priv/repo/migrations/20220604175030_create_persons.exs
@@ -1,0 +1,14 @@
+defmodule Ellion.Repo.Migrations.CreatePersons do
+  use Ecto.Migration
+
+  def change do
+    create table(:persons) do
+      add :alias, :string, size: 50
+      add :name, :string, size: 150, null: false
+      add :social_id, :string, size: 15, null: false
+      add :type, :integer, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20220604192944_create_addresses.exs
+++ b/priv/repo/migrations/20220604192944_create_addresses.exs
@@ -1,0 +1,21 @@
+defmodule Ellion.Repo.Migrations.CreateAddresses do
+  use Ecto.Migration
+
+  def change do
+    create table(:addresses) do
+      add :alias, :string, size: 15, null: false
+      add :street, :string, size: 150, null: false
+      add :number, :string, size: 15
+      add :complement, :string, size: 100
+      add :neighborhood, :string, size: 100
+      add :zip, :string, size: 15, null: false
+      add :city_id, references(:cities, on_delete: :restrict), null: false
+      add :person_id, references(:persons, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:addresses, [:city_id])
+    create index(:addresses, [:person_id])
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -17,6 +17,8 @@ defmodule EllionWeb.ChannelCase do
 
   use ExUnit.CaseTemplate
 
+  alias Ecto.Adapters.SQL
+
   using do
     quote do
       # Import conveniences for testing with channels
@@ -29,8 +31,8 @@ defmodule EllionWeb.ChannelCase do
   end
 
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
     :ok
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -17,6 +17,8 @@ defmodule EllionWeb.ConnCase do
 
   use ExUnit.CaseTemplate
 
+  alias Ecto.Adapters.SQL
+
   using do
     quote do
       # Import conveniences for testing with connections
@@ -32,8 +34,8 @@ defmodule EllionWeb.ConnCase do
   end
 
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -16,6 +16,8 @@ defmodule Ellion.DataCase do
 
   use ExUnit.CaseTemplate
 
+  alias Ecto.Adapters.SQL
+
   using do
     quote do
       alias Ellion.Repo
@@ -28,8 +30,8 @@ defmodule Ellion.DataCase do
   end
 
   setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
-    on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
+    pid = SQL.Sandbox.start_owner!(Ellion.Repo, shared: not tags[:async])
+    on_exit(fn -> SQL.Sandbox.stop_owner(pid) end)
     :ok
   end
 


### PR DESCRIPTION
### User Story
As a user I want to register individuals and organizations so that can be referenced in the entries

### Acceptance Criteria
- Individuals and organizations must allow registration, modification, viewing and deletion
- Individuals and organizations must allow registration of multiple addresses

### Data to be stored
- individual/organization: name, alias, social id, address
- addresses: alias, street, number, neighborhood, zip, city, state/province, country  

### Proposed Solution
- add resource `/persons` to manage individuals and organizations
- add resource `/persons/:id/addresses` to manage person's addresses

- add resource `/countries` to manage countries
- add resource `/countries/:id/states` to manage state/province/region by country
- add resource `/countries/:id/states/:id/cities` to manage cities by state/province/region

